### PR TITLE
Customize cache for info.json

### DIFF
--- a/salt/iiif/config/etc-nginx-sites-enabled-loris.conf
+++ b/salt/iiif/config/etc-nginx-sites-enabled-loris.conf
@@ -31,20 +31,40 @@ server {
 
     location / {
         uwsgi_pass loris;
-        #uwsgi_read_timeout 15s;
         include /etc/uwsgi/params;
         add_header Cache-Control "public, max-age=86400, immutable";
+        # http://agentzh.blogspot.co.uk/2011/03/how-nginx-location-if-works.html
+        if ($arg_fallback) {
+            add_header Cache-Control "public, max-age=86400, immutable";
+            add_header X-Iiif-Fallback 1;
+        }
 
         uwsgi_intercept_errors on;
         error_page 500 502 =200 @iiif_fallback;
     }
 
+    location ~ .*/info.json$ {
+        uwsgi_pass loris;
+        include /etc/uwsgi/params;
+        add_header Cache-Control "public, max-age=300";
+        if ($arg_fallback) { 
+            add_header Cache-Control "public, max-age=300";
+            add_header X-Iiif-Fallback 1;
+        }
+
+        uwsgi_intercept_errors on;
+        error_page 500 502 =200 @iiif_fallback_info_json;
+    }
+
     location @iiif_fallback {
-        # TODO: can we add an header or an indication that we are doing a fallback?
         {% for failing_format, fallback in pillar.iiif.fallback.iteritems() %}
-        rewrite ^/(.*)\.{{ failing_format }}(.*) /$1.{{ fallback }}$2 last;
-        #rewrite ^/(.*)\.{{ failing_format }}(.*)/info.json /$1.{{ fallback }}$2/info.json last;
+        rewrite ^/(.*)\.{{ failing_format }}(.*) /$1.{{ fallback }}$2?fallback=1 last;
         {% endfor %}
-        add_header X-Iiif-Fallback true;
+    }
+
+    location @iiif_fallback_info_json {
+        {% for failing_format, fallback in pillar.iiif.fallback.iteritems() %}
+        rewrite ^/(.*)\.{{ failing_format }}(.*) /$1.{{ fallback }}$2?fallback=1 last;
+        {% endfor %}
     }
 }


### PR DESCRIPTION
This seems to work using two different location blocks. The two additional fallback blocks use .jpg instead of .tif in case the .tif are not supported (10% of the figures); `if` has some strange behavior that makes me careful in using it, its purpose here is to add the X-Iiif-Fallback header