### PR TITLE
Simplify cache clean

### DIFF
--- a/salt/iiif/config/usr-local-bin-loris-cache-clean-hard
+++ b/salt/iiif/config/usr-local-bin-loris-cache-clean-hard
@@ -4,9 +4,6 @@ set -e
 
 LOG="/var/log/loris2/cache_clean.log"
 
-# rsync... http://www.slashroot.in/which-is-the-fastest-method-to-delete-files-in-linux
-# https://web.archive.org/web/20130929001850/http://linuxnote.net/jianingy/en/linux/a-fast-way-to-remove-huge-number-of-files.html
-BLANK_DIR="{{ pillar.iiif.loris.storage}}/blank"
 IMG_CACHE_ROOT_DIR="{{ pillar.iiif.loris.storage }}/cache-resolver"
 IMG_CACHE_DP_DIR="{{ pillar.iiif.loris.storage }}/cache-general"
 
@@ -18,8 +15,8 @@ log_message () {
 log_message "Started loris-cache-clean-hard"
 
 log_message "Removing $IMG_CACHE_ROOT_DIR contents"
-rsync -a --delete $BLANK_DIR/ $IMG_CACHE_ROOT_DIR/
+rm -r $IMG_CACHE_ROOT_DIR/*
 log_message "Removing $IMG_CACHE_DP_DIR contents"
-rsync -a --delete $BLANK_DIR/ $IMG_CACHE_DP_DIR/
+rm -r $IMG_CACHE_DP_DIR/*
 
 log_message "Cache completely purged!" 

--- a/salt/iiif/config/usr-local-bin-loris-cache-clean-hard
+++ b/salt/iiif/config/usr-local-bin-loris-cache-clean-hard
@@ -15,8 +15,8 @@ log_message () {
 log_message "Started loris-cache-clean-hard"
 
 log_message "Removing $IMG_CACHE_ROOT_DIR contents"
-rm -r $IMG_CACHE_ROOT_DIR/*
+rm -rf $IMG_CACHE_ROOT_DIR/*
 log_message "Removing $IMG_CACHE_DP_DIR contents"
-rm -r $IMG_CACHE_DP_DIR/*
+rm -rf $IMG_CACHE_DP_DIR/*
 
 log_message "Cache completely purged!" 


### PR DESCRIPTION
Avoids rsync, since it's a small performance improvement over simple commands but it's not going to solve our performance problems on cache cleaning.