### PR TITLE
ELPP-3521 Add non cacheable /ping

### DIFF
--- a/salt/iiif/config/etc-nginx-sites-enabled-loris.conf
+++ b/salt/iiif/config/etc-nginx-sites-enabled-loris.conf
@@ -36,6 +36,12 @@ server {
         return 200 "User-Agent: *\nDisallow: $robots_disallow\n";
     }
 
+    location = /ping {
+        add_header Cache-Control "must-revalidate, no-cache, no-store, private";
+        add_header Content-Type "text/plain; charset=UTF-8";
+        return 200 "pong";
+    }
+
     location / {
         uwsgi_pass loris;
         include /etc/uwsgi/params;

--- a/salt/iiif/config/usr-local-bin-loris-smoke
+++ b/salt/iiif/config/usr-local-bin-loris-smoke
@@ -3,4 +3,5 @@
 . /opt/smoke.sh/smoke.sh
 
 smoke_url_ok "http://localhost/"
+smoke_url_ok "http://localhost/ping"
 smoke_report


### PR DESCRIPTION
Useful for testing CDNs and as a standard healthcheck in general.