### PR TITLE
Handle multiple X-Forwarded-Host values

### DIFF
--- a/salt/iiif/config/etc-nginx-sites-enabled-loris.conf
+++ b/salt/iiif/config/etc-nginx-sites-enabled-loris.conf
@@ -2,13 +2,11 @@ upstream loris {
     server unix:///tmp/loris-uwsgi.sock;
 }
 
-# Fastly does not forward the Host header but sets the origins' one, we use the custom Elife-Orig-Host:
+# Fastly does not forward the Host header but sets the origins' one, we use the custom X-Forwarded-Host:
 # https://github.com/elifesciences/builder/blob/master/src/buildercore/fastly/vcl/original-host.vcl
 map $http_x_forwarded_host $robots_disallow {
-    hostnames;
-
     default "/";
-    iiif.elifesciences.org "";
+    "~^iiif.elifesciences.org\s*(?:,|$)" "";
 }
 
 server {


### PR DESCRIPTION
Same problem as https://github.com/elifesciences/journal-formula/pull/79 (though looks like setting the third-level domain when using `hostnames` doesn't work). So this must have been broken since we turned on Fastly Shielding (~5 weeks ago).

Currently:

```console
$ curl https://iiif.elifesciences.org/robots.txt
User-Agent: *
Disallow: /
$ curl https://prod--iiif.elifesciences.org/robots.txt -H "X-Forwarded-Host: iiif.elifesciences.org"
User-Agent: *
Disallow:
$ curl https://prod--iiif.elifesciences.org/robots.txt -H "X-Forwarded-Host: iiif.elifesciences.org, iiif.elifesciences.org"
User-Agent: *
Disallow: /
```

/cc @Maelplaine @StuartRFKing