### PR TITLE
fix, elifesciences/loris image is now always pulled from remote

### DIFF
--- a/salt/iiif/config/etc-nginx-sites-enabled-loris-container.conf
+++ b/salt/iiif/config/etc-nginx-sites-enabled-loris-container.conf
@@ -61,6 +61,7 @@ server {
 
         add_header Cache-Control "public, max-age=31536000, immutable";
         # http://agentzh.blogspot.co.uk/2011/03/how-nginx-location-if-works.html
+        # see also: https://nginx.org/en/docs/http/ngx_http_core_module.html#var_arg_
         if ($arg_fallback) {
             add_header Cache-Control "public, max-age=31536000, immutable";
             add_header X-Iiif-Fallback 1;

--- a/salt/iiif/init.sls
+++ b/salt/iiif/init.sls
@@ -1,6 +1,7 @@
 get-loris:
     docker_image.present:
         - name: elifesciences/loris:latest
+        - force: true
         - require:
             - docker-ready
 
@@ -187,6 +188,9 @@ run-loris:
             - newrelic-python-logfile-agent-in-ini-configuration
             {% endif %}
         - watch:
+            # if the image has changed, restart
+            - get-loris
+            # if the config has changed, restart
             {% if pillar.elife.newrelic.enabled %}
             - newrelic-python-logfile-agent-in-ini-configuration
             {% endif %}


### PR DESCRIPTION
* salt now fetches the latest elifesciences/loris image
* updated watches
