### PR TITLE
.env file for IMAGE_TAG and HOSTNAME variables.

### DIFF
--- a/salt/iiif/config/opt-loris-.env
+++ b/salt/iiif/config/opt-loris-.env
@@ -1,0 +1,2 @@
+IMAGE_TAG={{ salt['elife.image_tag']() }}
+HOSTNAME={{ salt['elife.cfg']('project.full_hostname') }}

--- a/salt/iiif/config/opt-loris-docker-compose.yaml
+++ b/salt/iiif/config/opt-loris-docker-compose.yaml
@@ -1,8 +1,8 @@
 version: '3.7'
 services:
     uwsgi:
-        image: "elifesciences/loris:latest"
-        hostname: {{ salt['elife.cfg']('project.full_hostname') }} # "prod--iiif.elifesciences.org"
+        image: "elifesciences/loris:${IMAGE_TAG}"
+        hostname: ${HOSTNAME} # "prod--iiif.elifesciences.org"
         environment:
             NEW_RELIC_ENABLED: "{{ pillar.elife.newrelic.enabled }}"
         # 2021-03-22: this makes the output unparseable for loggly so we can't target fields to create alerts.

--- a/salt/iiif/init.sls
+++ b/salt/iiif/init.sls
@@ -132,7 +132,7 @@ build-loris:
         - onlyif:
             - test -e /vagrant/loris-docker/Dockerfile
 
-{% endif %}        
+{% endif %}
 
 log-file-monitoring:
     file.managed:
@@ -144,6 +144,14 @@ log-file-monitoring:
         - watch_in:
             - service: syslog-ng
 
+
+loris-docker-compose-.env:
+    file.managed:
+        - name: /opt/loris/.env
+        - source: salt://iiif/config/opt-loris-.env
+        - template: jinja
+        - require:
+            - loris-dir
 
 loris-docker-compose:
     file.managed:
@@ -160,6 +168,7 @@ run-loris:
         - template: jinja
         - require:
             - loris-docker-compose
+            - loris-docker-compose-.env
 
     service.running:
         - name: iiif-service
@@ -195,6 +204,7 @@ run-loris:
             - loris-uwsgi-config
             - loris-config
             - loris-docker-compose
+            - loris-docker-compose-.env
 
 
 loris-nginx-ready:


### PR DESCRIPTION
the shifting of vars to a separate file shouldn't affect how things are right now, but it does let us pull values from build_vars that Jenkins can affect after the image has gone through testing.