### PR TITLE
properly support the tif->jpg fallback mechanism, elifesciences/issues#9086

### DIFF
--- a/salt/iiif/config/etc-caddy-sites.d-loris-container.conf
+++ b/salt/iiif/config/etc-caddy-sites.d-loris-container.conf
@@ -7,7 +7,7 @@
         }
     }
 
-    handle /favicon.ico { 
+    handle /favicon.ico {
         skip_log
         respond "Not Found" 404
     }
@@ -60,14 +60,37 @@
             path_regexp loris_prefix ^/({{ pillar.iiif.loris.templates.keys()|join("|") }})/(.*)$
         }
         rewrite @loris_prefix /{http.regexp.loris_prefix_info.1}:{http.regexp.loris_prefix_info.2}
+
         # header cache control if image
         header * Cache-Control "public, max-age=31536000, immutable"
+
         # header cache control if info.json
         header *info.json Cache-Control "public, max-age=300"
-        # force jpg rendering for tif
+
         reverse_proxy localhost:5004 {
             transport http {
                 read_timeout 15s
+            }
+
+            # 'fallback' hack.
+            # in cases where converting the tiff image throws an exception, request the jpg version instead.
+            @fallback {
+                status 500 502
+            }
+            handle_response {
+                {% for failing_format, fallback in pillar.iiif.fallback.items() %}
+                @loris_fallback_{{ failing_format }} {
+                    path_regexp loris_fallback_{{ failing_format }} ^/(.*)\.{{ failing_format }}(.*)$
+                }
+                rewrite @loris_fallback_{{ failing_format }} /{http.regexp.loris_fallback_{{ failing_format }}.1}.{{ fallback }}{http.regexp.loris_fallback_{{ failing_format }}.2}?fallback=1
+                {% endfor %}
+
+                # try again
+                reverse_proxy localhost:5004 {
+                    transport http {
+                        read_timeout 15s
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
The issue raised when we rolled this out to production looks like incorrect config for the fallback mechanism that existed in the nginx config.

This set of changes should allow a failed request with .tif files to be retried with jpg