### PR TITLE
Fix uwsgi handle empty responses

### DIFF
--- a/salt/iiif/config/etc-caddy-sites.d-loris-container.conf
+++ b/salt/iiif/config/etc-caddy-sites.d-loris-container.conf
@@ -77,7 +77,7 @@
             @fallback {
                 status 500 502
             }
-            handle_response {
+            handle_response @fallback {
                 {% for failing_format, fallback in pillar.iiif.fallback.items() %}
                 @loris_fallback_{{ failing_format }} {
                     path_regexp loris_fallback_{{ failing_format }} ^/(.*)\.{{ failing_format }}(.*)$

--- a/salt/iiif/config/opt-loris-uwsgi.ini
+++ b/salt/iiif/config/opt-loris-uwsgi.ini
@@ -20,3 +20,4 @@ wsgi-file=/var/www/loris2/loris2.wsgi
 
 enable-threads=True
 single-interpreter=True
+catch-exceptions=True


### PR DESCRIPTION
The fallback behaviour was not being triggered because uwsgi server was returning an empty response on exception. Caddy then treats this as a gateway error, not a proxy response to be handled.

This tells uwsgi to handle exceptions, and returns a correct status and response to Caddy, triggering the fallback behaviour