### PR TITLE
better fix for invalid uwsgi response code 0 elifesciences/issues#9086

### DIFF
--- a/salt/iiif/config/etc-caddy-sites.d-loris-container.conf
+++ b/salt/iiif/config/etc-caddy-sites.d-loris-container.conf
@@ -75,7 +75,7 @@
             # 'fallback' hack.
             # in cases where converting the tiff image throws an exception, request the jpg version instead.
             @fallback {
-                status 500 502
+                status 500 502 0
             }
             handle_response @fallback {
                 {% for failing_format, fallback in pillar.iiif.fallback.items() %}

--- a/salt/iiif/config/opt-loris-uwsgi.ini
+++ b/salt/iiif/config/opt-loris-uwsgi.ini
@@ -20,4 +20,3 @@ wsgi-file=/var/www/loris2/loris2.wsgi
 
 enable-threads=True
 single-interpreter=True
-catch-exceptions=True


### PR DESCRIPTION
Better because the exception catcher shouldn't  be used in prod env, even though it gets hidden anyway